### PR TITLE
Hotfix/image upload

### DIFF
--- a/src/main/java/com/select/choice/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/select/choice/domain/comment/controller/CommentController.java
@@ -30,7 +30,6 @@ public class CommentController {
         commentService.edit(commentIdx, commentDto);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
-
     @DeleteMapping("/{commentIdx}")
     public ResponseEntity<Void> delete(@PathVariable("commentIdx") Long commentIdx){
         commentService.delete(commentIdx);

--- a/src/main/java/com/select/choice/domain/image/controller/ImageController.java
+++ b/src/main/java/com/select/choice/domain/image/controller/ImageController.java
@@ -1,4 +1,28 @@
 package com.select.choice.domain.image.controller;
 
+
+import com.select.choice.domain.image.data.dto.ImageUploadDto;
+import com.select.choice.domain.image.service.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/image")
 public class ImageController {
+    private final ImageService imageService;
+    @PostMapping()
+    public ResponseEntity<String> imageUpload(@RequestPart(value = "file", required = false)MultipartFile image) throws IOException {
+        ImageUploadDto imageUploadDto = imageService.uploadImage(image);
+        return new ResponseEntity<>(imageUploadDto.getImageUrl(),HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/select/choice/domain/image/controller/ImageController.java
+++ b/src/main/java/com/select/choice/domain/image/controller/ImageController.java
@@ -1,0 +1,4 @@
+package com.select.choice.domain.image.controller;
+
+public class ImageController {
+}

--- a/src/main/java/com/select/choice/domain/image/service/ImageService.java
+++ b/src/main/java/com/select/choice/domain/image/service/ImageService.java
@@ -6,5 +6,5 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 
 public interface ImageService {
-    ImageUploadDto uploadImage(MultipartFile multipartFile) throws IOException;
+    ImageUploadDto uploadImage(MultipartFile image) throws IOException;
 }

--- a/src/main/java/com/select/choice/domain/post/domain/presentation/controller/PostController.java
+++ b/src/main/java/com/select/choice/domain/post/domain/presentation/controller/PostController.java
@@ -33,7 +33,7 @@ public class PostController {
         return ResponseEntity.ok(body);
     }
     @PostMapping()
-    public ResponseEntity<Void> createPost(CreatePostRequestDto createPostRequestDto) {
+    public ResponseEntity<Void> createPost(@RequestBody CreatePostRequestDto createPostRequestDto) {
         CreatePostDto dto = postConverter.toCreatePost(createPostRequestDto);
         postService.createPost(dto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -41,7 +41,7 @@ public class PostController {
     @DeleteMapping("/{postIdx}")
     public ResponseEntity<Void> deletePost(@PathVariable("postIdx") Long postIdx){
         postService.deletePost(postIdx);
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
 }

--- a/src/main/java/com/select/choice/domain/post/domain/presentation/controller/PostController.java
+++ b/src/main/java/com/select/choice/domain/post/domain/presentation/controller/PostController.java
@@ -33,11 +33,9 @@ public class PostController {
         return ResponseEntity.ok(body);
     }
     @PostMapping()
-    public ResponseEntity<Void> createPost(
-            @RequestPart(value = "file", required = false)MultipartFile image,
-            @RequestPart(value = "req") CreatePostRequestDto createPostRequestDto) throws Exception{
+    public ResponseEntity<Void> createPost(CreatePostRequestDto createPostRequestDto) {
         CreatePostDto dto = postConverter.toCreatePost(createPostRequestDto);
-        postService.createPost(dto,image);
+        postService.createPost(dto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
     @DeleteMapping("/{postIdx}")

--- a/src/main/java/com/select/choice/domain/post/domain/service/PostService.java
+++ b/src/main/java/com/select/choice/domain/post/domain/service/PostService.java
@@ -12,7 +12,7 @@ public interface PostService {
 
     List<PostDto> getAllPostList();
     List<PostDto> getBestPostList();
-    void createPost(CreatePostDto createPostDto, MultipartFile image) throws IOException;
+    void createPost(CreatePostDto createPostDto);
 
     void deletePost(Long postIdx);
 }

--- a/src/main/java/com/select/choice/domain/post/domain/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/select/choice/domain/post/domain/service/impl/PostServiceImpl.java
@@ -42,13 +42,9 @@ public class PostServiceImpl implements PostService {
     }
     @Transactional
     @Override
-    public void createPost(CreatePostDto postDto, MultipartFile image) throws IOException {
+    public void createPost(CreatePostDto postDto) {
         User user = userFacade.currentUser();
         Post post = postConverter.toEntity(postDto, user);
-        if(!image.isEmpty()) {
-            ImageUploadDto imageUploadDto = imageService.uploadImage(image);
-            post.updateThumbnail(imageUploadDto.getImageUrl());
-        }
         postRepository.save(post);
     }
 


### PR DESCRIPTION
## 제목
image upload 수정
## 작업 내용
image uoload를 하는 방식을 endpoint를 따로따로 나누어 게시물을 생성할때 게시물에 이미지를 업로드를 할 수 있도록 로직을 구현 하였다.
## 내부로직
 file을 request로 받고 file을 aws s3에 담아 s3 url을 반환해준다.
## 주의 사항
나중에 리팩토링 다시한번 하겠습니다. (좋게)